### PR TITLE
Don't reposition the clock when pulling down the notification bar

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -2166,9 +2166,6 @@ public class NotificationPanelView extends PanelView implements
 
         // Hide "No notifications" in QS.
         mNotificationStackScroller.updateEmptyShadeView(mShadeEmpty && !mQsExpanded);
-        if (mStatusBarState == StatusBarState.KEYGUARD) {
-            positionClockAndNotifications();
-        }
     }
 
     public void setQsScrimEnabled(boolean qsScrimEnabled) {


### PR DESCRIPTION
positionClockAndNotifications() is causing the digital clock to
abruptly fade and shrink when pulling down the notification bar,
while it should slowly fade away and only while swiping up to
unlock the screen.

Change-Id: I455798c1dfc880353334dbe9d1b8ac0c6b5bc87c